### PR TITLE
chore: renaming logcraft-cli crates name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2622,8 +2622,8 @@ dependencies = [
  "futures",
  "indicatif",
  "kclvm-api",
- "logcraft-common",
- "logcraft-runtime",
+ "lgc-common",
+ "lgc-runtime",
  "openssl",
  "rayon",
  "serde",
@@ -2635,6 +2635,62 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "wasmtime",
+]
+
+[[package]]
+name = "lgc-common"
+version = "0.1.3"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "console",
+ "dashmap 6.0.1",
+ "dialoguer",
+ "futures",
+ "inquire",
+ "kclvm-api",
+ "kclvm-query",
+ "kclvm-sema",
+ "lgc-runtime",
+ "rayon",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "serde_yaml_ng",
+ "similar",
+ "tempfile",
+ "tokio",
+ "tokio-util 0.7.11",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "uuid",
+ "wasmtime",
+]
+
+[[package]]
+name = "lgc-runtime"
+version = "0.1.3"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "crossbeam-channel",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "tokio",
+ "tokio-native-tls",
+ "tracing",
+ "tracing-subscriber",
+ "wasmparser 0.211.1",
+ "wasmtime",
+ "wasmtime-wasi",
+ "wasmtime-wasi-http",
+ "wit-component",
+ "wit-parser 0.211.1",
 ]
 
 [[package]]
@@ -2710,62 +2766,6 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
-
-[[package]]
-name = "logcraft-common"
-version = "0.1.3"
-dependencies = [
- "anyhow",
- "async-trait",
- "console",
- "dashmap 6.0.1",
- "dialoguer",
- "futures",
- "inquire",
- "kclvm-api",
- "kclvm-query",
- "kclvm-sema",
- "logcraft-runtime",
- "rayon",
- "regex",
- "reqwest",
- "serde",
- "serde_json",
- "serde_with",
- "serde_yaml_ng",
- "similar",
- "tempfile",
- "tokio",
- "tokio-util 0.7.11",
- "tracing",
- "tracing-subscriber",
- "url",
- "uuid",
- "wasmtime",
-]
-
-[[package]]
-name = "logcraft-runtime"
-version = "0.1.3"
-dependencies = [
- "anyhow",
- "async-trait",
- "crossbeam-channel",
- "futures",
- "http",
- "http-body-util",
- "hyper",
- "tokio",
- "tokio-native-tls",
- "tracing",
- "tracing-subscriber",
- "wasmparser 0.211.1",
- "wasmtime",
- "wasmtime-wasi",
- "wasmtime-wasi-http",
- "wit-component",
- "wit-parser 0.211.1",
-]
 
 [[package]]
 name = "lsp-server"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,8 +59,8 @@ figment = { version = "0.10", features = ["yaml", "env"] }
 envsubst = "0.2"
 
 # Local dependencies
-logcraft-common = { path = "crates/common", version = "0.1.3" }
-logcraft-runtime = { path = "crates/runtime", version = "0.1.3" }
+lgc-common = { path = "crates/common", version = "0.1.3" }
+lgc-runtime = { path = "crates/runtime", version = "0.1.3" }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 openssl = { version = "0.10", features = ["vendored"] }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 [package]
-name = "logcraft-common"
+name = "lgc-common"
 description = "LogCraft common utilities"
 version.workspace = true
 authors.workspace = true
@@ -44,4 +44,4 @@ regex = "1.10"
 serde_with = "3.8"
 
 # Local dependencies
-logcraft-runtime = { path = "../runtime" }
+lgc-runtime = { path = "../runtime" }

--- a/crates/common/src/plugins/manager.rs
+++ b/crates/common/src/plugins/manager.rs
@@ -3,7 +3,7 @@
 
 use anyhow::{anyhow, bail, Result};
 use async_trait::async_trait;
-use logcraft_runtime::{
+use lgc_runtime::{
     plugin_component::plugin::Metadata, state::State, Config, Engine, Plugins,
     DEFAULT_EPOCH_TICK_INTERVAL,
 };

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 [package]
-name = "logcraft-runtime"
+name = "lgc-runtime"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/src/bin/lgc.rs
+++ b/src/bin/lgc.rs
@@ -15,8 +15,8 @@ use lgc::commands::{
     environments::EnvironmentsCommands, init::InitCommand, plugins::PluginsCommands,
     services::ServicesCommands, validate::ValidateCommand,
 };
-use logcraft_common::configuration::{ProjectConfiguration, LGC_CONFIG_PATH};
-use logcraft_common::utils::env_forbidden_chars;
+use lgc_common::configuration::{ProjectConfiguration, LGC_CONFIG_PATH};
+use lgc_common::utils::env_forbidden_chars;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::{env, fs};

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, bail, Result};
 use clap::Parser;
 use console::style;
 use dialoguer::{theme::ColorfulTheme, Confirm, Select};
-use logcraft_common::{
+use lgc_common::{
     configuration::{Environment, ProjectConfiguration, Service},
     detections::{compare_detections, map_plugin_detections, DetectionState, ServiceDetections},
     plugins::manager::{PluginActions, PluginManager},

--- a/src/commands/destroy.rs
+++ b/src/commands/destroy.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, bail, Result};
 use clap::Parser;
 use console::style;
 use dialoguer::{theme::ColorfulTheme, Confirm, Select};
-use logcraft_common::{
+use lgc_common::{
     configuration::{Environment, ProjectConfiguration, Service},
     plugins::manager::{PluginActions, PluginManager},
 };

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, Result};
 use clap::Parser;
 use console::style;
 use dialoguer::{theme::ColorfulTheme, Select};
-use logcraft_common::{
+use lgc_common::{
     configuration::{Environment, ProjectConfiguration, Service},
     detections::{
         compare_detections, map_plugin_detections, DetectionState, PluginDetections,

--- a/src/commands/environments.rs
+++ b/src/commands/environments.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, bail, Ok, Result};
 use clap::{Parser, Subcommand};
 use console::style;
 use dialoguer::{theme::ColorfulTheme, Input, Select};
-use logcraft_common::{
+use lgc_common::{
     configuration::{Environment, ProjectConfiguration},
     utils::ensure_kebab_case,
 };

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -3,7 +3,7 @@
 
 use anyhow::{bail, Result};
 use clap::Parser;
-use logcraft_common::configuration::{ProjectConfiguration, LGC_CONFIG_PATH, LGC_RULES_DIR};
+use lgc_common::configuration::{ProjectConfiguration, LGC_CONFIG_PATH, LGC_RULES_DIR};
 use std::{
     env::current_dir,
     fmt::Debug,

--- a/src/commands/plugins.rs
+++ b/src/commands/plugins.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, bail, Result};
 use clap::{Parser, Subcommand};
 use console::style;
 use dialoguer::{theme::ColorfulTheme, Confirm, Input, Select};
-use logcraft_common::{
+use lgc_common::{
     configuration::ProjectConfiguration,
     plugins::{
         cleanup_plugin, determine_plugin_location,
@@ -166,7 +166,7 @@ impl UninstallPlugin {
         if !self.force
             && !services.is_empty()
             && !Confirm::with_theme(&prompt_theme)
-                .with_prompt(&format!(
+                .with_prompt(format!(
                     "This plugin is used in `{}` services(s), force removal ?",
                     style(services.join(", ")).red()
                 ))

--- a/src/commands/services.rs
+++ b/src/commands/services.rs
@@ -6,7 +6,7 @@ use clap::{Parser, Subcommand};
 use console::style;
 use dialoguer::{theme::ColorfulTheme, Confirm, Input, Select};
 use indicatif::{ProgressBar, ProgressStyle};
-use logcraft_common::{
+use lgc_common::{
     configuration::{ProjectConfiguration, Service},
     plugins::manager::{PluginActions, PluginManager},
     utils,

--- a/src/commands/validate.rs
+++ b/src/commands/validate.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 use kclvm_api::{gpyrpc::ValidateCodeArgs, service::KclvmServiceImpl};
 use tokio::task::JoinSet;
 
-use logcraft_common::{
+use lgc_common::{
     configuration::ProjectConfiguration,
     detections::map_plugin_detections,
     plugins::manager::{PluginActions, PluginManager},


### PR DESCRIPTION
Renaming LogCraft cli crates names to `lgc-<crate_name<>` to avoid crate name conflicts.